### PR TITLE
when NODE_PATH is on process.env, loop over each path and add to paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ module.exports = function npmPaths(options) {
 
   if (process.env.NODE_PATH) {
     var nodePaths = process.env.NODE_PATH.split(path.delimiter);
-    addPath(nodePaths.filter(Boolean));
+    nodePaths.filter(Boolean)
+      .forEach(addPath);
   } else {
 
     addPath(path.join(gm, modulePath || ''));


### PR DESCRIPTION
Before this fix, the `NODE_PATH` array was being added causing the sort function below to fail.
This fix just adds each path after the filter has been processed to remove blank or undefined paths.
